### PR TITLE
Update MinimalEncoder.java

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/MinimalEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/MinimalEncoder.java
@@ -192,7 +192,7 @@ public final class MinimalEncoder {
 
       if (thirdsCount % 3 == 0 || ((thirdsCount - 2) % 3 == 0 && i + 1 == input.length())) {
         characterLength[0] = i - from + 1;
-        return (int) Math.ceil(((double) thirdsCount) / 3.0);
+        return (int) Math.ceil(thirdsCount / 3.0);
       }
     }
     characterLength[0] = 0;


### PR DESCRIPTION
This pull request includes a minor change to the `MinimalEncoder` class in the `core/src/main/java/com/google/zxing/datamatrix/encoder/MinimalEncoder.java` file. The change simplifies a mathematical operation by removing an unnecessary cast to `double` during a division.

* Simplified the calculation of the number of C40 words by removing the explicit cast to `double` in the `Math.ceil` function, as the division already produces a `double` result. (`[core/src/main/java/com/google/zxing/datamatrix/encoder/MinimalEncoder.javaL195-R195](diffhunk://#diff-01edcf582ec3632c26128f986d5d8d3e1d86fd2cd84806333229b3770c13d936L195-R195)`)